### PR TITLE
july 2020: post meeting revisions

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                             <td scope="row" nowrap>Jun 3rd</td>
                             <td>Board</td>
                             <td>Online (Zoom)</td>
-                            <!-- <td><a href="http://www.sfpride.org/wp-content/uploads/2020/06/June_BoardPacket_SFPride-1.pdf">Agenda</a> + <a href="">Minutes</a> (pdf)</td> -->
+                            <td><a href="http://www.sfpride.org/wp-content/uploads/2020/06/June_BoardPacket_SFPride-1.pdf">Agenda</a> (pdf)</td>
                         </tr>
                         <tr>
                             <td scope="row" nowrap>Jun 10</td>
@@ -162,16 +162,16 @@
                             <td>Online (Zoom)</td>
                             <td><a href="https://storage.googleapis.com/files.members.sfpride.org/AGENDA%20Member%20Meeting_JUN%202020.pdf">Agenda</a> (pdf)</td>
                         </tr>
-                        <tr class="bg-warning">
+                        <tr>
                             <td scope="row" nowrap>Jul 15th<sup>*</sup></td>
                             <td>Board</td>
-                            <td><a href="https://us02web.zoom.us/j/88257890203?pwd=ZTBTQ0ZPTDVMMzlkR2lMYVZlclRmQT09">Zoom Webinar</a> </td>
+                            <td>Online (Zoom)</td>
                             <td><a href="https://www.sfpride.org/wp-content/uploads/2020/07/July_2020_BOD_Packet.pdf">Agenda + Reports</a></td>
                         </tr>
                         <tr>
                             <td scope="row" nowrap>Aug 5th</td>
                             <td>Board</td>
-                            <td>Location TBA</td>
+                            <td><a href="https://us02web.zoom.us/j/88257890203?pwd=ZTBTQ0ZPTDVMMzlkR2lMYVZlclRmQT09">Zoom Webinar</a></td>
                             <td></td>
                         </tr>
                         <tr>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <a class="btn text-info float-right" href="https://www.sfpride.org/wp-content/uploads/2020/07/BYLAWS-POLICIES_SFPride_010220-1.pdf" target="_blank">Bylaws</a>
         </header>
 
-        <div class="alert alert-warning text-center alert-dismissible fade show" role="alert">
+        <div class="alert alert-warning text-center alert-dismissible fade show d-none" role="alert">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
                 <span class="sr-only">Close</span>
@@ -29,7 +29,7 @@
             <p>It has come to our attention that an erroneous link to the <i title="2020/07/08">July membership meeting</i> may have been sent out. <br>Meeting minutes will be posted here as soon as possible, and we apologize for the inconvenience.</p>
         </div>
 
-        <div class="jumbotron text-center">
+        <div class="jumbotron text-center d-none">
             <h2>Board of Directors Meeting</h2>
             <p class="lead">July 15th, 2020 at 7:00pm</p>
             <div class="text-center btn-group mb-3">


### PR DESCRIPTION
- disable the meeting link box at the top
- remove alert about old email
- move board webinar link for next meeting

![](https://user-images.githubusercontent.com/3653760/87716367-9a249580-c763-11ea-9373-2e1243b81980.png)

